### PR TITLE
Log ppid on error

### DIFF
--- a/libutempter/Makefile
+++ b/libutempter/Makefile
@@ -38,10 +38,10 @@ man3dir = $(mandir)/man3
 DESTDIR =
 
 WARNINGS = -W -Wall -Waggregate-return -Wcast-align -Wconversion \
-	-Wdisabled-optimization -Wmissing-declarations \
+	-Wdisabled-optimization -Wformat=2 -Wmissing-declarations \
 	-Wmissing-format-attribute -Wmissing-noreturn \
 	-Wmissing-prototypes -Wpointer-arith -Wredundant-decls \
-	-Wshadow -Wstrict-prototypes -Wwrite-strings
+	-Wshadow -Wstrict-prototypes -Wundef -Wunused -Wwrite-strings
 COMPILE_DIALECT = -std=gnu99
 COMPILE_LFS =
 COMPILE_PIC = -fPIC

--- a/libutempter/diag.h
+++ b/libutempter/diag.h
@@ -22,6 +22,7 @@
 # define UTEMPTER_DIAG_H
 
 # include <syslog.h>
+# include <unistd.h>
 
 # ifdef UTEMPTER_LOG
 #  define log_debug(fmt_, ...) syslog(LOG_DEBUG, fmt_, ##__VA_ARGS__)
@@ -45,12 +46,12 @@
 	} while (0)					\
 /* End of debug_msg definition.  */
 
-# define fatal_error(fmt_, ...)				\
-	do {						\
-		log_error(fmt_, ##__VA_ARGS__);		\
-		print_dbg(fmt_, ##__VA_ARGS__);		\
-		exit(EXIT_FAILURE);			\
-	} while (0)					\
+# define fatal_error(fmt_, ...)							\
+	do {									\
+		log_error("[ppid=%ld] " fmt_, (long)getppid(), ##__VA_ARGS__);	\
+		print_dbg(fmt_, ##__VA_ARGS__);					\
+		exit(EXIT_FAILURE);						\
+	} while (0)								\
 /* End of fatal_error definition.  */
 
 #endif /* UTEMPTER_DIAG_H */


### PR DESCRIPTION
When sending an error message to syslog include the parent PID to ease
debugging which program actually called utempter and did so in an
erroneous way.