### PR TITLE
Makefile: add STATIC and DYNAMIC build variables

### DIFF
--- a/libutempter/Makefile
+++ b/libutempter/Makefile
@@ -27,7 +27,15 @@ SONAME = $(SHAREDLIB).$(MAJOR)
 STATICLIB = lib$(PROJECT).a
 MAP = lib$(PROJECT).map
 
-TARGETS = $(PROJECT) $(SHAREDLIB)
+STATIC ?= 0
+DYNAMIC ?= 1
+TARGETS = $(PROJECT)
+ifeq ($(DYNAMIC),1)
+TARGETS += $(SHAREDLIB)
+endif
+ifeq ($(STATIC),1)
+TARGETS += $(STATICLIB)
+endif
 
 INSTALL = install
 libdir = /usr/lib
@@ -81,9 +89,14 @@ install:
 		$(DESTDIR)$(includedir) $(DESTDIR)$(man3dir)
 	$(INSTALL) -p -m2711 $(PROJECT) $(DESTDIR)$(libexecdir)/$(PROJECT)/
 	$(INSTALL) -p -m644 $(PROJECT).h $(DESTDIR)$(includedir)/
+ifeq ($(DYNAMIC),1)
 	$(INSTALL) -p -m755 $(SHAREDLIB) $(DESTDIR)$(libdir)/$(SHAREDLIB).$(VERSION)
 	ln -fns $(SHAREDLIB).$(VERSION) $(DESTDIR)$(libdir)/$(SONAME)
 	ln -fns $(SONAME) $(DESTDIR)$(libdir)/$(SHAREDLIB)
+endif
+ifeq ($(STATIC),1)
+	$(INSTALL) -p -m644 $(STATICLIB) $(DESTDIR)$(libdir)/
+endif
 	$(INSTALL) -p -m644 $(PROJECT).3 $(DESTDIR)$(man3dir)/
 	for n in lib$(PROJECT) utempter_add_record utempter_remove_record \
 	    utempter_remove_added_record utempter_set_helper; do \


### PR DESCRIPTION
This change adds two new Makefile variables, `STATIC` and `DYNAMIC`, which provide control over whether the static and shared libraries are built and installed.

The `STATIC` variable defaults to `0` and, when set to `1`, builds and installs the static library `libutempter.a`. The `DYNAMIC` variable defaults to `1` and, when set to `1`, builds and installs the shared library `libutempter.so`. Setting either variable to `0` skips building and installing the corresponding library.

When neither variable is touched on the command line, the old behavior is preserved: the shared library is built and installed as before, while the static library is not built or installed.

Users can now selectively build either library or both. For example, running `make STATIC=1` builds both libraries, while `make DYNAMIC=0 STATIC=1` builds only the static library. Similarly, the `install` target respects these variables, so `make install STATIC=1` installs both libraries and `make install DYNAMIC=0 STATIC=1` installs only the static library.